### PR TITLE
Update license meta-data in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ authors = [
 ]
 description = "Fast Levenshtein and Damerau optimal string alignment algorithms."
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 keywords = ["edit distance", "levenshtein", "damerau"]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Natural Language :: English",


### PR DESCRIPTION
Updated license meta data to comply with PEP 639.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files